### PR TITLE
Use default rather than native quality

### DIFF
--- a/source/viewer/mirador/js/src/iiif.js
+++ b/source/viewer/mirador/js/src/iiif.js
@@ -18,7 +18,7 @@
 
     getUriWithHeight: function(uri, height) {
       uri = uri.replace(/\/$/, '');
-      return this.getUri(uri) + '/full/,' + height + '/0/native.jpg';
+      return this.getUri(uri) + '/full/,' + height + '/0/default.jpg';
     },
 
 


### PR DESCRIPTION
Stanford's IIIF server does not support `native` any longer.